### PR TITLE
Secure file permissions for config files

### DIFF
--- a/roles/nut/tasks/client.yml
+++ b/roles/nut/tasks/client.yml
@@ -10,7 +10,7 @@
     dest: /etc/nut/upsmon.conf
     owner: root
     group: nut
-    mode: '0644'
+    mode: "0640"
   notify: Restart NUT Client
 
 - name: Generate NUT Notification Script
@@ -19,5 +19,5 @@
     dest: /etc/nut/notifycmd
     owner: root
     group: nut
-    mode: '0775'
+    mode: "0775"
   notify: Restart NUT Client

--- a/roles/nut/tasks/server.yml
+++ b/roles/nut/tasks/server.yml
@@ -10,7 +10,7 @@
     dest: "/etc/nut/{{ item }}"
     owner: root
     group: nut
-    mode: '0644'
+    mode: "0640"
   notify:
     - Restart NUT Server
   loop:


### PR DESCRIPTION
Some nut config files contain secrets, therefore they should be restricted from all users.