### PR TITLE
Do not iterate over AnsibleVaultEncryptedUnicode in upsd.users config

### DIFF
--- a/roles/nut/templates/upsd.users.j2
+++ b/roles/nut/templates/upsd.users.j2
@@ -3,7 +3,7 @@
 {% for user in nut_upsd_users %}
 [{{ user }}]
 {% for option in nut_upsd_users[user] %}
-{%- if nut_upsd_users[user][option] is iterable and not nut_upsd_users[user][option] is string %}
+{%- if nut_upsd_users[user][option] is iterable and not nut_upsd_users[user][option] is string and ( nut_upsd_users[user][option] | type_debug ) != 'AnsibleVaultEncryptedUnicode' %}
 {%- for repeat in nut_upsd_users[user][option] %}
   {{ option }} = {{ repeat }}{{ '\n' }}
 {%- endfor %}


### PR DESCRIPTION
Best practices require nut user passwords to be encrypted as vault items in playbooks.  This change fixes an issue where a decrypted vault secret was not of type string and therefore would be iterated over character by character.

fixes #409 