### PR TITLE
Deprecate support for older ansible-core versions

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.18.0"


### PR DESCRIPTION
According to the ansible-core support matrix: https://docs.ansible.com/ansible-core/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix