### PR TITLE
Rename variable for consistency in docker-compose restart handling

### DIFF
--- a/roles/docker_compose_stack/handlers/main.yml
+++ b/roles/docker_compose_stack/handlers/main.yml
@@ -7,7 +7,7 @@
   ansible.builtin.systemd:
     name: "docker-compose@{{ stack_name }}.service"
     state: restarted
-  register: docker_compose_restart_result
+  register: docker_compose_stack_restart_result
   failed_when: false
   # Below we use a custom loop to only restart services for stacks that had changes in their configuration or dependencies
   loop: >-

--- a/roles/docker_compose_stack/tasks/main.yml
+++ b/roles/docker_compose_stack/tasks/main.yml
@@ -174,7 +174,7 @@
       }}
   loop: >-
     {{
-      docker_compose_restart_result.results
+      docker_compose_stack_restart_result.results
       | default([])
       | selectattr('failed', 'defined')
       | selectattr('failed', 'equalto', true)
@@ -188,7 +188,7 @@
       {{ item.msg | default(item.stderr, true) }}
   loop: >-
     {{
-      docker_compose_restart_result.results
+      docker_compose_stack_restart_result.results
       | default([])
       | selectattr('failed', 'defined')
       | selectattr('failed', 'equalto', true)


### PR DESCRIPTION
Update variable name for the result of the docker-compose restart to ensure consistency throughout the code.